### PR TITLE
Fix batchGetItems for resolved table name resources

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -32,7 +32,7 @@ internals.mergeResponses = (tableName, responses) => {
   }, base);
 };
 
-internals.paginatedRequest = (request, table, callback) => {
+internals.paginatedRequest = (request, table, resolvedTableName, callback) => {
   const responses = [];
 
   const moreKeysToProcessFunc = () => request !== null && !_.isEmpty(request);
@@ -59,8 +59,7 @@ internals.paginatedRequest = (request, table, callback) => {
     if (err) {
       return callback(err);
     }
-
-    callback(null, internals.mergeResponses(table.tableName(), responses));
+    callback(null, internals.mergeResponses(resolvedTableName, responses));
   };
 
   async.doWhilst(doFunc, moreKeysToProcessFunc, resulsFunc);
@@ -81,17 +80,20 @@ internals.initialBatchGetItems = (keys, table, serializer, options, callback) =>
 
   const request = internals.buildInitialGetItemsRequest(table.tableName(), serializedKeys, options);
 
-  internals.paginatedRequest(request, table, (err, data) => {
-    if (err) {
-      return callback(err);
-    }
+  table.getResolvedTableName()
+    .then((resolvedTableName) => {
+      internals.paginatedRequest(request, table, resolvedTableName, (err, data) => {
+        if (err) {
+          return callback(err);
+        }
 
-    const dynamoItems = data.Responses[table.tableName()];
+        const dynamoItems = data.Responses[resolvedTableName];
 
-    const items = _.map(dynamoItems, i => table.initItem(serializer.deserializeItem(i)));
+        const items = _.map(dynamoItems, i => table.initItem(serializer.deserializeItem(i)));
 
-    return callback(null, items);
-  });
+        return callback(null, items);
+      });
+    });
 };
 
 internals.getItems = (table, serializer) => (keys, options, callback) => {

--- a/lib/table.js
+++ b/lib/table.js
@@ -48,6 +48,15 @@ Table.prototype.tableName = function () {
   }
 };
 
+Table.prototype.getResolvedTableName = function () {
+  if (Object.prototype.hasOwnProperty.call(this.docClient, 'tableResolver')) {
+    return this.docClient.tableResolver.resolve('get', { TableName: this.tableName() })
+      .then(res => res.TableName);
+  } else {
+    return Promise.resolve(this.tableName());
+  }
+};
+
 Table.prototype.sendRequest = function (method, params, callback) {
   const self = this;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d2l/dynogels",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d2l/dynogels",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Ryan Fitzgerald <ryan@codebrewstudios.com>",
   "contributors": [
     "Clarkie <andrew.t.clarke@gmail.com> (http://clarkie.io)"

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -21,6 +21,7 @@ describe('Batch', () => {
     table = helper.mockTable();
     table.serializer = Serializer;
     table.tableName = () => 'accounts';
+    table.getResolvedTableName = () => Promise.resolve('accounts');
 
     const config = {
       hashKey: 'name',


### PR DESCRIPTION
- Previously, the items returned by the resolved request would be partitioned under the base table name
- Now, we resolve the table name after retrieving the data, and use that as the key for partitioning instead