### PR TITLE
Allow empty arrays to be set on an item

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -33,7 +33,7 @@ Item.prototype.set = function (paramsOrKey, value) {
     this.attrs = _.mergeWith({}, this.attrs, paramsOrKey, (originalParam, sourceParam) =>
       // Lodash's merge and mergeWith ignore empty arrays by default.
       // This customizer function allows empty arrays to be set.
-      (_.isArray(sourceParam) ? sourceParam : undefined));
+      ((_.isArray(sourceParam) && sourceParam.length === 0) ? sourceParam : undefined));
   }
 
   return this;

--- a/lib/item.js
+++ b/lib/item.js
@@ -30,7 +30,10 @@ Item.prototype.set = function (paramsOrKey, value) {
   if (_.isString(paramsOrKey)) {
     this.attrs[paramsOrKey] = value;
   } else {
-    this.attrs = _.merge({}, this.attrs, paramsOrKey);
+    this.attrs = _.mergeWith({}, this.attrs, paramsOrKey, (originalParam, sourceParam) =>
+      // Lodash's merge and mergeWith ignore empty arrays by default.
+      // This customizer function allows empty arrays to be set.
+      (_.isArray(sourceParam) ? sourceParam : undefined));
   }
 
   return this;

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -111,6 +111,24 @@ describe('item', () => {
       item.set('num', 123);
       expect(item.get('num')).to.equal(123);
     });
+
+    it('should set an empty array', () => {
+      const item = new Item({ array: [1, 2, 3] });
+      item.set({ array: [] });
+      const setField = item.get('array');
+      expect(setField).to.be.an('array');
+      expect(setField).to.be.have.length(0);
+    });
+
+    it('should combine objects in array when setting array field', () => {
+      const item = new Item({ a: [{ b: 2 }, { d: 4 }] });
+      item.set({ a: [{ c: 3 }, { e: 5 }] });
+      const setField = item.get('a');
+      expect(setField[0].b).to.equal(2);
+      expect(setField[0].c).to.equal(3);
+      expect(setField[1].d).to.equal(4);
+      expect(setField[1].e).to.equal(5);
+    });
   });
 });
 

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -117,7 +117,7 @@ describe('item', () => {
       item.set({ array: [] });
       const setField = item.get('array');
       expect(setField).to.be.an('array');
-      expect(setField).to.be.have.length(0);
+      expect(setField).to.have.length(0);
     });
 
     it('should combine objects in array when setting array field', () => {


### PR DESCRIPTION
In Dynogels, `item.set()` uses Lodash's `merge()` function to combine existing attributes and new attributes. However, by default, `merge()` will ignore empty arrays.

This commit changes the behaviour to allow empty arrays to be set.

This will allow us to change [this part](https://github.com/Brightspace/d2l-content-service/blob/b27c5b3f8c74d9d70be9d15af03fe511eb434813/api/routers/api/_tenantId/content.js#L313) of the `PUT /content/:id` route in Content Service to use:

```javascript
content.set(updatedAttributes);
await content.saveAsync();
```

without unintentionally removing empty arrays.