### PR TITLE
Add "previousAttrs" option for passing pre-update data to before hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,9 @@ Account.update(
 );
 ```
 
+You can also use `options.previousAttrs` to pass in item data from before modification. If it's defined, the before hook for "update" will
+receive that data as its second argument. See [the hooks examples file](examples/hooks.js) for more details.
+
 This is essentially short-hand for:
 ```js
 var params = {};

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -24,8 +24,12 @@ Account.before('create', (data, next) => {
   next(null, data);
 });
 
-Account.before('update', (data, next) => {
-  data.age = 45;
+Account.before('update', (data, previousAttrs, next) => {
+  if (previousAttrs.age === 45) {
+    data.age = 50;
+  } else {
+    data.age = 45;
+  }
   next(null, data);
 });
 
@@ -51,10 +55,16 @@ dynogels.createTables((err) => {
   }
 
   Account.create({ email: 'test11@example.com' }, (err, acc) => {
-    acc.set({ age: 25 });
+    let previousAttrs = JSON.parse(JSON.stringify(acc.attrs));
+    acc.set({ age: 25 }); // becomes 45 after update
 
-    acc.update(() => {
-      acc.destroy({ ReturnValues: 'ALL_OLD' });
+    acc.update({ previousAttrs }, () => {
+      previousAttrs = JSON.parse(JSON.stringify(acc.attrs));
+      acc.set({ age: 30 }); // becomes 50 after update
+
+      acc.update({ previousAttrs }, () => {
+        acc.destroy({ ReturnValues: 'ALL_OLD' });
+      });
     });
   });
 });

--- a/lib/table.js
+++ b/lib/table.js
@@ -320,7 +320,11 @@ Table.prototype.update = function (item, options, callback) {
       item[paramName] = new Date().toISOString();
     }
 
-    return callback(null, item);
+    if (options.previousAttrs) {
+      return callback(null, item, options.previousAttrs);
+    } else {
+      return callback(null, item);
+    }
   }, (err, data) => {
     if (err) {
       return callback(err);

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -2117,6 +2117,52 @@ describe('table', () => {
         table.update(item, () => { });
       });
 
+      it('should call before hook that takes previousAttrs', (done) => {
+        const config = {
+          hashKey: 'email',
+          schema: {
+            email: Joi.string(),
+            name: Joi.string(),
+            age: Joi.number()
+          }
+        };
+
+        const s = new Schema(config);
+
+        table = new Table('accounts', s, serializer, docClient, logger);
+
+        const item = { email: 'test@test.com', name: 'Tim Test', age: 23 };
+        const previousAttrs = JSON.parse(JSON.stringify(item));
+        docClient.update.yields(null, {});
+
+        serializer.serializeItem.withArgs(s, item).returns({});
+
+        serializer.buildKey.returns({ email: { S: 'test@test.com' } });
+        const modified = { email: 'test@test.com', name: 'Tim Test', age: 44 };
+        serializer.serializeItemForUpdate.withArgs(s, 'PUT', modified).returns({});
+
+        serializer.deserializeItem.returns(modified);
+        docClient.update.yields(null, {});
+
+        let called = false;
+        table.before('update', (data, previousAttrs, next) => {
+          if (previousAttrs.age === 23) {
+            const attrs = _.merge({}, data, { age: 44 });
+            called = true;
+            return next(null, attrs);
+          } else {
+            return next(new Error('previous attributes not passed in correctly'));
+          }
+        });
+
+        table.after('update', () => {
+          expect(called).to.be.true;
+          return done();
+        });
+
+        table.update(item, { previousAttrs }, () => { });
+      });
+
       it('should return error when before hook returns error', (done) => {
         const config = {
           hashKey: 'email',


### PR DESCRIPTION
This PR adds a `previousAttrs` option to the Dynogel Table class' `update()` function. Callers of `update()` can set `previousAttrs` to the item's set of attributes from before any modifications were made. If set, `previousAttrs` will be provided to the "before update" hook as an argument.

This allows update hooks to compare new and old attribute data before the actual update operation is executed.