### PR TITLE
Attempt to fix publish by using https for repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "ci": "make coverage",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },
-  "repository": "git://github.com/Brightspace/dynogels.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Brightspace/dynogels.git"
+  },
   "keywords": [
     "datamapper",
     "DynamoDB",


### PR DESCRIPTION
Error from the most recent Github Actions run:
```
'**semantic-release** cannot push the version tag to the branch `master` on the remote Git repository with URL `https://x-access-token:[secure]@github.com/Brightspace/dynogels.git`.\n' +
    '\n' +
    'This can be caused by:\n' +
    ' - a misconfiguration of the [repositoryUrl](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#repositoryurl) option\n' +
    ' - the repository being unavailable\n' +
    ' - or missing push permission for the user configured via the [Git credentials on your CI environment](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/ci-configuration.md#authentication)',
```

According to the [semantic-release docs](https://github.com/Brightspace/dynogels.git), `repositoryUrl` will by default use the value of "repository" in package.json.

In this repo, "repository" was using the git protocol (`git://github.com/Brightspace/dynogels.git`), which has been deprecated due to lack of authentication.

This PR changes the protocol to https, which is [what BSI uses](https://github.com/Brightspace/brightspace-integration/blob/bddbc131f29f1a69b58102e954f956c42e049a67/package.json#L20).