### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "node": ">=4"
   },
   "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "async": "2.5.0",
     "aws-sdk": "^2.408.0",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564